### PR TITLE
Add missing foreman dev dependency

### DIFF
--- a/examples/collaborative-text-editor/Gemfile
+++ b/examples/collaborative-text-editor/Gemfile
@@ -56,6 +56,7 @@ gem "y-rb_actioncable", path: "../../gems/yrb-actioncable"
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]
+  gem "foreman"
 end
 
 group :development do

--- a/examples/collaborative-text-editor/Gemfile
+++ b/examples/collaborative-text-editor/Gemfile
@@ -56,7 +56,6 @@ gem "y-rb_actioncable", path: "../../gems/yrb-actioncable"
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]
-  gem "foreman"
 end
 
 group :development do

--- a/examples/collaborative-text-editor/Procfile.dev
+++ b/examples/collaborative-text-editor/Procfile.dev
@@ -1,4 +1,4 @@
 web: unset PORT && bin/rails server
 js: yarn build:js --watch
 css: bin/rails tailwindcss:watch
-redis: redis-server
+redis: docker run --rm --name redis -p 6379:6379 redis:7-alpine


### PR DESCRIPTION
We need to include `foreman` in the `development` group here so we can `bundle exec foreman start` to run the example app.

I also patched `Procfile.dev` to run a redis container instead of relying on a host redis to exist. There seems to be duplication/overlap with the procfile defined in the gem folder from which I lifted this (which I don't think we need, since a gem is not an application we need to run? :thinking: )