### PR TITLE
WIP: Add docker-compose setup for sample app

### DIFF
--- a/examples/collaborative-text-editor/bin/dev-containers
+++ b/examples/collaborative-text-editor/bin/dev-containers
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+set -uxe
+
+export BASE_DIR=$(realpath "$(pwd)/../../")
+
+docker-compose up

--- a/examples/collaborative-text-editor/bin/rails-entrypoint
+++ b/examples/collaborative-text-editor/bin/rails-entrypoint
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+set -uxe
+
+bundle config set --local path "/bundled_gems"
+bundle install
+
+rm -f tmp/pids/server.pid
+bin/rails server

--- a/examples/collaborative-text-editor/config/cable.yml
+++ b/examples/collaborative-text-editor/config/cable.yml
@@ -1,6 +1,6 @@
 development:
   adapter: redis
-  url: redis://localhost:6379/1
+  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
 
 test:
   adapter: test

--- a/examples/collaborative-text-editor/config/puma.rb
+++ b/examples/collaborative-text-editor/config/puma.rb
@@ -15,9 +15,7 @@ threads min_threads_count, max_threads_count
 #
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-#
-port ENV.fetch("PORT", 3000)
+bind "tcp://0.0.0.0:#{ENV.fetch("PORT", 3000)}"
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/examples/collaborative-text-editor/docker-compose.yml
+++ b/examples/collaborative-text-editor/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3'
+
+services:
+  rails:
+    image: ruby:3.2.0
+    working_dir: /work/examples/collaborative-text-editor
+    command: bin/rails-entrypoint
+    ports:
+      - "3000:3000"
+    environment:
+      - REDIS_URL=redis://redis:6379/1
+    volumes:
+      - ${BASE_DIR}:/work
+      - bundled_gems:/bundled_gems
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:6.2-alpine
+    volumes:
+      - redis_data:/data
+    expose:
+      - 6379
+
+volumes:
+  bundled_gems:
+  redis_data:


### PR DESCRIPTION
I might have gotten a bit carried away with this, but I found the amount of setup necessary to get such a simple app running quite distracting. So I thought I'd take a stab at containerizing this. I want to have a simple `up`/`down` script that just works and installs anything automatically if missing.

This PR has some issues still:

- The default Docker user is root, and  we write stuff to `tmp` (such as the puma pidfile) which is mounted into the container. I tried setting the UID to the host user, but this then resulted in the bundler volume not being writable anymore and I couldn't figure out how to fix that
- I think the entrypoint script is missing some installation steps since we don't just need bundler dependencies but also yarn/npm? I think this only works for me currently because these are installed into `node_modules` when you install these locally, and that dir is under the tree mounted into the container so this isn't fully "plug and play" yet