### PR TITLE
fix: Y::Lib0::Decoding.read_var_uint8_array increments decoder's `pos`

### DIFF
--- a/gems/yrb-actioncable/lib/y/lib0/decoding.rb
+++ b/gems/yrb-actioncable/lib/y/lib0/decoding.rb
@@ -28,6 +28,8 @@ module Y
 
       def self.read_uint8_array(decoder, size)
         view = Buffer.create_uint8_array_view_from_buffer(decoder.arr, decoder.pos + 0, size)
+        decoder.pos += size
+        view
       end
 
       def self.read_var_uint8_array(decoder)


### PR DESCRIPTION
closes https://github.com/y-crdt/yrb-actioncable/issues/108

